### PR TITLE
Remove DISTINCT for faster query.

### DIFF
--- a/sparql/subclass-closure-construct.sparql
+++ b/sparql/subclass-closure-construct.sparql
@@ -2,7 +2,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 PREFIX rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX owl:  <http://www.w3.org/2002/07/owl#>
-SELECT DISTINCT  ?s (rdfs:subClassOf AS ?p) ?o 
+SELECT ?s (rdfs:subClassOf AS ?p) ?o 
 WHERE {
     ?s rdfs:subClassOf* ?o .
     FILTER(isIRI(?s))


### PR DESCRIPTION
I tested this on a fresh pipeline build. It completed in 54 minutes and produced a 24G file (slightly bigger but comparable to old pipeline). I'm using jena 3.12.0, in case that is different from what's been tested before.