### PR TITLE
Absence from presence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,6 +163,7 @@ $(BUILD_DIR)/phenex-data-merged.ofn: $(NEXML_OWLS)
 $(BUILD_DIR)/phenoscape-kb-tbox-classified.ttl: $(BUILD_DIR)/phenoscape-kb-tbox-classified-plus-absence.ttl
 	$(ROBOT) reason \
 	--reasoner ELK \
+	--axiom-generators "SubClass EquivalentClass" \
 	--exclude-duplicate-axioms true \
 	--exclude-tautologies structural \
 	--i $< \
@@ -193,6 +194,7 @@ $(BUILD_DIR)/phenoscape-kb-tbox-classified-pre-absence-reasoning.ofn: $(BUILD_DI
 	$(ROBOT) reason \
 	-i $< \
 	--reasoner ELK \
+	--axiom-generators "SubClass EquivalentClass" \
 	--exclude-duplicate-axioms true \
 	--exclude-tautologies structural \
 	convert --format ofn \
@@ -357,6 +359,7 @@ $(BUILD_DIR)/bio-ontologies-classified.ttl: $(BUILD_DIR)/bio-ontologies-merged.t
 	remove --term 'owl:Nothing' --trim true \
 	reason \
 	--reasoner ELK \
+	--axiom-generators "SubClass EquivalentClass" \
 	--exclude-duplicate-axioms true \
 	--exclude-tautologies structural \
 	convert --format ttl \

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -6,15 +6,6 @@ PREFIX obo: <http://purl.obolibrary.org/obo/>
 
 SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {
-?taxon rdfs:isDefinedBy <http://purl.obolibrary.org/obo/vto.owl> .
-?entity rdfs:isDefinedBy <http://purl.obolibrary.org/obo/uberon.owl> .
-?taxon ps:exhibits_state/ps:describes_phenotype ?phenotype .
-?phenotype owl:equivalentClass/owl:intersectionOf/rdf:rest*/rdf:first ?hasPartRestriction .
-?hasPartRestriction owl:onProperty obo:BFO_0000051 .
-?hasPartRestriction owl:someValuesFrom/owl:intersectionOf ?operands .
-?operands rdf:rest*/rdf:first obo:PATO_0002000 .
-?operands rdf:rest*/rdf:first ?valueRestriction .
-?valueRestriction owl:onProperty obo:RO_0002503 .
-?valueRestriction owl:hasValue ?phenotypeEntity .
+?taxon ps:exhibits_state/ps:describes_phenotype/rdfs:subClassOf/ps:absence_of ?phenotypeEntity .
 ?entity ^ps:implies_presence_of_some/rdfs:subClassOf/ps:implies_presence_of_some ?phenotypeEntity .
 }

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -1,5 +1,8 @@
+PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX ps: <http://purl.org/phenoscape/vocab.owl#>
+PREFIX obo: <http://purl.obolibrary.org/obo/>
 
 SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -8,4 +8,5 @@ SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {
 ?taxon ps:exhibits_state/ps:describes_phenotype/rdfs:subClassOf/ps:absence_of ?phenotypeEntity .
 ?entity ^ps:implies_presence_of_some/rdfs:subClassOf/ps:implies_presence_of_some ?phenotypeEntity .
+?entity <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://purl.obolibrary.org/obo/uberon.owl> .
 }

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -4,6 +4,7 @@ PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX ps: <http://purl.org/phenoscape/vocab.owl#>
 PREFIX obo: <http://purl.obolibrary.org/obo/>
 
+# Assumes reflexive rdfs:subClassOf closure
 SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {
 ?taxon ps:exhibits_state/ps:describes_phenotype/rdfs:subClassOf/ps:absence_of ?phenotypeEntity .

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -1,14 +1,17 @@
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX ps: <http://purl.org/phenoscape/vocab.owl#>
 
-SELECT ?taxon (ps:has_absence_of AS ?p) ?entity
+SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {
-
-?taxon <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://purl.obolibrary.org/obo/vto.owl> .
-?entity <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://purl.obolibrary.org/obo/uberon.owl> .
-
-?taxon <http://purl.org/phenoscape/vocab.owl#exhibits_state>/<http://purl.org/phenoscape/vocab.owl#describes_phenotype>/(<http://www.w3.org/2000/01/rdf-schema#subClassOf>)/<http://purl.org/phenoscape/vocab.owl#absence_of> ?entity .
-
-#?taxon rdfs:subClassOf* <http://purl.obolibrary.org/obo/VTO_0000001> .
-#?entity rdfs:subClassOf* <http://purl.obolibrary.org/obo/UBERON_0001062>
+?taxon rdfs:isDefinedBy <http://purl.obolibrary.org/obo/vto.owl> .
+?entity rdfs:isDefinedBy <http://purl.obolibrary.org/obo/uberon.owl> .
+?taxon ps:exhibits_state/ps:describes_phenotype ?phenotype .
+?phenotype owl:equivalentClass/owl:intersectionOf/rdf:rest*/rdf:first ?hasPartRestriction .
+?hasPartRestriction owl:onProperty obo:BFO_0000051 .
+?hasPartRestriction owl:someValuesFrom/owl:intersectionOf ?operands .
+?operands rdf:rest*/rdf:first obo:PATO_0002000 .
+?operands rdf:rest*/rdf:first ?valueRestriction .
+?valueRestriction owl:onProperty obo:RO_0002503 .
+?valueRestriction owl:hasValue ?phenotypeEntity .
+?entity ^ps:implies_presence_of_some/rdfs:subClassOf/ps:implies_presence_of_some ?phenotypeEntity .
 }

--- a/sparql/absences.sparql
+++ b/sparql/absences.sparql
@@ -8,5 +8,6 @@ SELECT DISTINCT ?taxon (ps:has_absence_of AS ?p) ?entity
 WHERE {
 ?taxon ps:exhibits_state/ps:describes_phenotype/rdfs:subClassOf/ps:absence_of ?phenotypeEntity .
 ?entity ^ps:implies_presence_of_some/rdfs:subClassOf/ps:implies_presence_of_some ?phenotypeEntity .
-?entity <http://www.w3.org/2000/01/rdf-schema#isDefinedBy> <http://purl.obolibrary.org/obo/uberon.owl> .
+?entity rdfs:isDefinedBy <http://purl.obolibrary.org/obo/uberon.owl> .
+?taxon rdfs:isDefinedBy <http://purl.obolibrary.org/obo/vto.owl> .
 }

--- a/sparql/subclass-closure-construct.sparql
+++ b/sparql/subclass-closure-construct.sparql
@@ -7,6 +7,6 @@ SELECT ?s (rdfs:subClassOf AS ?p) ?o
 WHERE {
     ?s rdf:type owl:Class .
     FILTER(isIRI(?s))
-    ?s rdfs:subClassOf*|owl:equivalentClass ?o .
+    ?s rdfs:subClassOf*|owl:equivalentClass|^owl:equivalentClass ?o .
     FILTER(isIRI(?o))
 }

--- a/sparql/subclass-closure-construct.sparql
+++ b/sparql/subclass-closure-construct.sparql
@@ -7,6 +7,6 @@ SELECT ?s (rdfs:subClassOf AS ?p) ?o
 WHERE {
     ?s rdf:type owl:Class .
     FILTER(isIRI(?s))
-    ?s rdfs:subClassOf*|owl:equivalentClass|^owl:equivalentClass ?o .
+    ?s rdfs:subClassOf*|owl:equivalentClass+|^owl:equivalentClass+ ?o .
     FILTER(isIRI(?o))
 }

--- a/sparql/subclass-closure-construct.sparql
+++ b/sparql/subclass-closure-construct.sparql
@@ -7,6 +7,6 @@ SELECT ?s (rdfs:subClassOf AS ?p) ?o
 WHERE {
     ?s rdf:type owl:Class .
     FILTER(isIRI(?s))
-    ?s rdfs:subClassOf* ?o .
+    ?s rdfs:subClassOf*|owl:equivalentClass ?o .
     FILTER(isIRI(?o))
 }


### PR DESCRIPTION
Simplify absence reasoning, so that it is just a "reverse" query of presence inferences. Fix problems with missing materialized equivalent class triples.