### PR TITLE
Test Makefile using placeholder scripts

### DIFF
--- a/.github/workflows/test-makefile.yml
+++ b/.github/workflows/test-makefile.yml
@@ -1,0 +1,18 @@
+name: Test Makefile
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - run: npm install yargs
+      - run: git clone --depth 1 https://github.com/phenoscape/phenoscape-data.git
+      - run: ./test/test-makefile.sh 

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build/
+node_modules

--- a/README.md
+++ b/README.md
@@ -56,3 +56,27 @@ The build process involves
 All these ontologies are merged into a single ontology, reasoned over to generate tbox and abox axioms, and finally combined together to form the Phenoscape-KB.
 
 `ontology-versions.ttl` contains metadata about the ontologies used in a particular kb build.
+
+# Testing
+
+## Makefile Testing
+The Makefile can be tested using placeholder programs via the test/test-makefile.sh script.
+The placeholder scripts are in the test/bin directory and create empty output files.
+
+### Requirements
+To run this script requires [nodejs](https://nodejs.org/) and GNU sed in your PATH.
+The placeholder scripts requirements can be installed like os:
+```
+npm install yargs
+```
+
+### Running
+The Makefile test can be run as follows:
+```
+./tests/test-makefile.sh
+```
+If the exit status of the above script is 0 the tests succeeded.
+The script will also print the following message when everything passed:
+```
+SUCCESS: Makefile tests passed.
+```

--- a/test/bin/arq
+++ b/test/bin/arq
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+console.log("Running fake arq command.")
+

--- a/test/bin/blazegraph-runner
+++ b/test/bin/blazegraph-runner
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake blazegraph-runner command.")
+
+const argv = helper.getArgv()
+helper.createFile(argv.journal)

--- a/test/bin/curl
+++ b/test/bin/curl
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake curl command.")
+
+const argv = helper.getArgv()
+// first positional argument is a command
+helper.createFile(argv.o)
+

--- a/test/bin/dosdp-tools
+++ b/test/bin/dosdp-tools
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake dosdp-tools command.")
+
+const argv = helper.getArgv()
+helper.createFile(argv.outfile)

--- a/test/bin/helper.js
+++ b/test/bin/helper.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+
+const yargs = require('yargs/yargs')
+const { hideBin } = require('yargs/helpers')
+const fs = require('fs')
+const path = require('path');
+
+module.exports = {
+    getArgv: function() {
+        return yargs(hideBin(process.argv)).argv
+    },
+    createFile: function(filePath) {
+        const dir = path.dirname(filePath)
+        if (!fs.existsSync(dir)){
+            fs.mkdirSync(dir, { recursive: true });
+        }
+        fs.closeSync(fs.openSync(filePath, 'w'));
+    }
+}

--- a/test/bin/kb-owl-tools
+++ b/test/bin/kb-owl-tools
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake kb-owl-tools command.")
+
+const argv = helper.getArgv()
+// first positional argument is a command
+const cmd = argv._[0]
+switch (cmd) {
+  case "convert-nexml":
+  case "assert-negation-hierarchy":
+  case "output-evolutionary-profiles":
+  case "expects-to-triples":
+  case "output-profile-sizes":
+  case "output-ics":
+    const outfile = argv._[argv._.length - 1]
+    helper.createFile(outfile)
+    break
+  case "pairwise-sim":
+    // last two positional arguments are files to create
+    helper.createFile(argv._[argv._.length - 1])
+    helper.createFile(argv._[argv._.length - 2])
+    break
+  default:
+    console.log("Unknown command:", cmd)
+    process.exit(1)
+}

--- a/test/bin/python
+++ b/test/bin/python
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake python command.")
+
+const argv = helper.getArgv()
+// first positional argument is a python script
+const script = argv._[0]
+switch (script) {
+  case "/tools/regression.py":
+    helper.createFile(argv._[argv._.length - 1])
+    break
+  default:
+    console.log("Unknown python script:", script)
+    process.exit(1)
+}

--- a/test/bin/riot
+++ b/test/bin/riot
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log("Running fake riot command.")

--- a/test/bin/robot
+++ b/test/bin/robot
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+
+var helper = require('./helper.js')
+
+console.log("Running fake robot command.")
+
+const argv = helper.getArgv()
+// first positional argument is a command
+const cmd = argv._[0]
+switch (cmd) {
+  case "query":
+    helper.createFile(argv._[1])
+    break
+  case "mirror":
+  case "merge":
+  case "reason":
+  case "remove":
+    helper.createFile(argv.o)
+    break
+  default:
+    console.log("Unknown command:", cmd)
+    process.exit(1)
+}

--- a/test/test-makefile.sh
+++ b/test/test-makefile.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Test makefile with dummy programs.
+# This script should be run from the base directory of this repo.
+
+# stop if a command fails (non-zero exit status)
+set -e
+
+# if this script fails show a message with the line number 
+SCRIPTNAME=$0
+trap 'echo "ERROR on line $LINENO of $SCRIPTNAME"' ERR
+
+# Put fake bin scripts first in the PATH
+export PATH=$(pwd)/test/bin:$PATH
+
+# start with a clean slate
+make clean
+
+# Run make to create our files
+make all
+
+# Check that the major files were created
+echo "Checking that build/phenoscape-kb.ttl exists"
+test -f build/phenoscape-kb.ttl
+
+echo "Checking that build/phenoscape-kb-tbox-hierarchy.ttl exists"
+test -f build/phenoscape-kb-tbox-hierarchy.ttl
+
+echo "Checking that build/blazegraph-loaded-all.jnl exists"
+test -f build/blazegraph-loaded-all.jnl
+
+
+# Run make a second time
+SECOND_TIME_OUTPUT=$(make all)
+
+echo "Checking that second 'make all' found nothing to be done"
+# grep will exit with 1 if nothing is found
+echo $SECOND_TIME_OUTPUT | grep 'Nothing to be done'
+
+echo ""
+echo "SUCCESS: Makefile tests passed."
+echo ""


### PR DESCRIPTION
Adds test/test-makefile.sh script to test the Makefile.
Adds test/bin/* placeholder scripts that simulate the various commands used by the Makefile.
Adds a github action to run the test on push.

Fixes #214

---

Creating a Draft PR to get feedback on this approach to testing just the Makefile.
I wrote the placeholder scripts in node to avoid conflicts with the programs being run by the Makefile and because node makes it easy to parse differing command line arguments.
 
